### PR TITLE
Fix component name generation

### DIFF
--- a/islands/ClickableIcon.tsx
+++ b/islands/ClickableIcon.tsx
@@ -1,16 +1,10 @@
 import { useState } from "preact/hooks";
 import { selection } from "../util/selection.ts";
 import { copy as copySignal } from "../util/copy.ts";
+import getIconComponentName from "../util/getIconComponentName.ts";
 
 interface ClickableIconProps {
   name: string;
-}
-
-function DashToCamelCase(str: string) {
-  return str.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
-}
-function uppercaseFirst(str: string) {
-  return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
 export default function ClickableIcon(props: ClickableIconProps) {
@@ -19,7 +13,7 @@ export default function ClickableIcon(props: ClickableIconProps) {
 
   const copy = (icon: string) => {
     return () => {
-      const className = "Icon" + uppercaseFirst(DashToCamelCase(icon));
+      const className = getIconComponentName(icon);
       const copyText =
         `import ${className} from "https://deno.land/x/tabler_icons_tsx@0.0.2/tsx/${icon}.tsx"`;
 

--- a/islands/CodeBlock.tsx
+++ b/islands/CodeBlock.tsx
@@ -3,20 +3,14 @@ import { selection } from "../util/selection.ts";
 import Prism from "https://esm.sh/prismjs@1.27.0";
 import "https://esm.sh/prismjs@1.27.0/components/prism-typescript?no-check";
 import { copy as copySignal } from "../util/copy.ts";
+import getIconComponentName from "../util/getIconComponentName.ts";
 interface CodeBlockProps {
   copy?: boolean;
 }
 
-function DashToCamelCase(str: string) {
-  return str.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
-}
-function uppercaseFirst(str: string) {
-  return str.charAt(0).toUpperCase() + str.slice(1);
-}
-
 export default function CodeBlock(props: CodeBlockProps) {
   const icon = selection.value === "" ? "brand-github" : selection.value;
-  const className = "Icon" + uppercaseFirst(DashToCamelCase(icon));
+  const className = getIconComponentName(icon);
   const example =
     `import ${className} from "https://deno.land/x/tabler_icons_tsx@0.0.2/tsx/${icon}.tsx"
 

--- a/islands/Examples.tsx
+++ b/islands/Examples.tsx
@@ -1,17 +1,12 @@
+import getIconComponentName from "../util/getIconComponentName.ts";
 import { selection } from "../util/selection.ts";
 import { copy as copySignal } from "../util/copy.ts";
 import IconExternalLink from "https://deno.land/x/tabler_icons_tsx@0.0.2/tsx/external-link.tsx";
 import { JSX } from "preact";
-function DashToCamelCase(str: string) {
-  return str.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
-}
-function uppercaseFirst(str: string) {
-  return str.charAt(0).toUpperCase() + str.slice(1);
-}
 
 export default function Examples() {
   const iconName = selection.value;
-  const className = "Icon" + uppercaseFirst(DashToCamelCase(iconName));
+  const className = getIconComponentName(iconName);
 
   return (
     <div class="space-y-16 text-center">

--- a/util/convert.ts
+++ b/util/convert.ts
@@ -1,5 +1,6 @@
 import svgr from "npm:@svgr/core";
 import type { Template } from "npm:@svgr/babel-plugin-transform-svg-component";
+import getIconComponentName from "./getIconComponentName.ts";
 
 export const tsxTemplate: Template = (variables, { tpl }) => {
   return tpl`
@@ -7,17 +8,6 @@ function ${variables.componentName}({ size = 24, color = "currentColor", stroke 
 
 ${variables.exports}
 `;
-};
-
-const camelize = function (str: string) {
-  str = str.replace(/-/g, " ");
-
-  return str.replace(
-    /(?:^\w|[A-Z]|\b\w)/g,
-    function (word: string, _) {
-      return word.toUpperCase();
-    },
-  ).replace(/\s+/g, "");
 };
 
 export async function svgToTsx(name: string, source: string) {
@@ -35,7 +25,7 @@ export async function svgToTsx(name: string, source: string) {
       template: tsxTemplate,
     },
     {
-      componentName: camelize("Icon-" + basename),
+      componentName: getIconComponentName(basename),
     },
   );
 

--- a/util/getIconComponentName.test.ts
+++ b/util/getIconComponentName.test.ts
@@ -1,0 +1,19 @@
+import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
+import getIconComponentName from "./getIconComponentName.ts";
+
+Deno.test("Icon name conversion", (_) => {
+  assertEquals(
+    "IconBoxMultiple3",
+    getIconComponentName("box-multiple-3"),
+  );
+
+  assertEquals(
+    "IconAB2",
+    getIconComponentName("a-b-2"),
+  );
+
+  assertEquals(
+    "Icon2fa",
+    getIconComponentName("2fa"),
+  );
+});

--- a/util/getIconComponentName.ts
+++ b/util/getIconComponentName.ts
@@ -1,0 +1,9 @@
+/**
+ * Convert an icon file basename (kebab-case) to its component name (IconPascalCase)
+ */
+export default function getIconComponentName(basename: string) {
+  return (
+    "Icon" +
+    basename.replace(/(?:^|-)(.)/g, (_, letter) => letter.toUpperCase())
+  );
+}


### PR DESCRIPTION
Previously, the component name was generated in multiple places, and it couldn't handle when the icon name contained numbers correctly in all cases.

Here is an example:

```tsx
// BEFORE
import IconBoxMultiple-3 from "https://deno.land/x/tabler_icons_tsx@0.0.2/tsx/box-multiple-3.tsx"

<IconBoxMultiple-3 class="w-6 h-6" />

// AFTER
import IconBoxMultiple3 from "https://deno.land/x/tabler_icons_tsx@0.0.2/tsx/box-multiple-3.tsx"

<IconBoxMultiple3 class="w-6 h-6" />
```

I've tested by running the icon conversion task. This code change causes no changes in the generated TSX code.