### PR TITLE
fix: replace all occurrences of camel case TSX attributes

### DIFF
--- a/util/convert.test.ts
+++ b/util/convert.test.ts
@@ -4,15 +4,20 @@ import { svgToTsx } from "./convert.ts";
 // want to use deno fmt
 import * as prettier from "npm:prettier";
 
-Deno.test("svg conversion", async (t) => {
+async function loadFixtures(component: string) {
   const svg = await Deno.readTextFile(
-    new URL("./fixtures/a-b.svg", import.meta.url).pathname,
+    new URL(`./fixtures/${component}.svg`, import.meta.url).pathname,
   );
   const tsx = await Deno.readTextFile(
-    new URL("./fixtures/a-b.tsx", import.meta.url).pathname,
+    new URL(`./fixtures/${component}.tsx`, import.meta.url).pathname,
   );
+  return { svg, tsx };
+}
 
-  const result = await svgToTsx("a-b", svg);
+Deno.test("svg conversion", async (t) => {
+  const component = "a-b";
+  const { svg, tsx } = await loadFixtures(component);
+  const result = await svgToTsx(component, svg);
 
   assertEquals(
     prettier.format(result, { parser: "babel" }),
@@ -22,13 +27,7 @@ Deno.test("svg conversion", async (t) => {
 
 Deno.test("regression test #7", async (t) => {
   const component = "alert-triangle-filled";
-  const svg = await Deno.readTextFile(
-    new URL(`./fixtures/${component}.svg`, import.meta.url).pathname,
-  );
-  const tsx = await Deno.readTextFile(
-    new URL(`./fixtures/${component}.tsx`, import.meta.url).pathname,
-  );
-
+  const { svg, tsx } = await loadFixtures(component);
   const result = await svgToTsx(component, svg);
 
   assertEquals(

--- a/util/convert.test.ts
+++ b/util/convert.test.ts
@@ -19,3 +19,20 @@ Deno.test("svg conversion", async (t) => {
     prettier.format(tsx, { parser: "babel" }),
   );
 });
+
+Deno.test("regression test #7", async (t) => {
+  const component = "alert-triangle-filled";
+  const svg = await Deno.readTextFile(
+    new URL(`./fixtures/${component}.svg`, import.meta.url).pathname,
+  );
+  const tsx = await Deno.readTextFile(
+    new URL(`./fixtures/${component}.tsx`, import.meta.url).pathname,
+  );
+
+  const result = await svgToTsx(component, svg);
+
+  assertEquals(
+    prettier.format(result, { parser: "babel" }),
+    prettier.format(tsx, { parser: "babel" }),
+  );
+});

--- a/util/convert.ts
+++ b/util/convert.ts
@@ -85,7 +85,7 @@ function replaceClassName(content: string) {
     },
   ];
   for (const pattern of patterns) {
-    content = content.replace(pattern.match, pattern.replace);
+    content = content.replaceAll(pattern.match, pattern.replace);
   }
   return content;
 }

--- a/util/fixtures/alert-triangle-filled.svg
+++ b/util/fixtures/alert-triangle-filled.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-alert-triangle-filled" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+   <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+   <path d="M11.94 2a2.99 2.99 0 0 1 2.45 1.279l.108 .164l8.431 14.074a2.989 2.989 0 0 1 -2.366 4.474l-.2 .009h-16.856a2.99 2.99 0 0 1 -2.648 -4.308l.101 -.189l8.425 -14.065a2.989 2.989 0 0 1 2.555 -1.438zm.07 14l-.127 .007a1 1 0 0 0 0 1.986l.117 .007l.127 -.007a1 1 0 0 0 0 -1.986l-.117 -.007zm-.01 -8a1 1 0 0 0 -.993 .883l-.007 .117v4l.007 .117a1 1 0 0 0 1.986 0l.007 -.117v-4l-.007 -.117a1 1 0 0 0 -.993 -.883z" stroke-width="0" fill="currentColor"></path>
+</svg>

--- a/util/fixtures/alert-triangle-filled.tsx
+++ b/util/fixtures/alert-triangle-filled.tsx
@@ -1,0 +1,30 @@
+function IconAlertTriangleFilled({
+  size = 24,
+  color = "currentColor",
+  stroke = 2,
+  ...props
+}) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      class="icon icon-tabler icon-tabler-alert-triangle-filled"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      stroke-width={stroke}
+      stroke={color}
+      fill="none"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      {...props}
+    >
+      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <path
+        d="M11.94 2a2.99 2.99 0 0 1 2.45 1.279l.108 .164l8.431 14.074a2.989 2.989 0 0 1 -2.366 4.474l-.2 .009h-16.856a2.99 2.99 0 0 1 -2.648 -4.308l.101 -.189l8.425 -14.065a2.989 2.989 0 0 1 2.555 -1.438zm.07 14l-.127 .007a1 1 0 0 0 0 1.986l.117 .007l.127 -.007a1 1 0 0 0 0 -1.986l-.117 -.007zm-.01 -8a1 1 0 0 0 -.993 .883l-.007 .117v4l.007 .117a1 1 0 0 0 1.986 0l.007 -.117v-4l-.007 -.117a1 1 0 0 0 -.993 -.883z"
+        stroke-width={0}
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+export default IconAlertTriangleFilled;


### PR DESCRIPTION
Without this change, the conversion results of e.g. filled icons such as [`tsx/alert-triangle-filled.tsx`](https://github.com/hashrock/tabler-icons-tsx/blob/9a0c5356e2ab7b884dc70db7fcddb4f3bfe4a9e7/tsx/alert-triangle-filled.tsx#L24) were broken because the second occurrence of `stroke-width` had been missed (which leads to a broken rendering).

I'm pretty sure that this does the trick, but I've been unable to test this locally:
Even before doing this change I tried to run `deno task convert`, which somehow resulted in all icons in the `tsx/` folder being overwritten with the source SVG, i.e. no conversion happened. For the same reason `deno task test` also failed.
Any idea what's going wrong with my setup?

> deno 1.32.5 (release, x86_64-unknown-linux-gnu)
> v8 11.2.214.9
> typescript 5.0.3